### PR TITLE
chore: remove usb mass storage

### DIFF
--- a/storefront_base.json
+++ b/storefront_base.json
@@ -78,13 +78,6 @@
       ]
     },
     {
-      "storefront_name": "USB Mass Storage",
-      "repo_url": "https://github.com/josegonzalez/trimui-brick-usb-mass-storage-pak",
-      "categories": [
-        "File Management"
-      ]
-    },
-    {
       "storefront_name": "Developer",
       "repo_url": "https://github.com/josegonzalez/minui-developer-pak",
       "categories": [


### PR DESCRIPTION
It seems to cause corruption for some users (not me) so better safe than sorry?