### PR TITLE
Add Atari800 emulator to storefront_base.json

### DIFF
--- a/storefront_base.json
+++ b/storefront_base.json
@@ -433,6 +433,13 @@
       "categories": [
         "Emulators"
       ]
+    },
+    {
+      "storefront_name": "Atari800",
+      "repo_url": "https://github.com/KrutzOtrem/nextui-a800",
+      "categories": [
+        "Emulators"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Tackling this issue: https://github.com/UncleJunVIP/nextui-pak-store/issues/35

But didn't try it on my device